### PR TITLE
Enable multiple consumers per event

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,10 @@ msbuild EventTrigger.sln
 ```
 
 Run the console application and enter credentials. The password `password` is considered valid.
+
+### Multiple consumers
+
+`Unity` is configured to resolve all registered implementations of `IConsumer<TEvent>`.
+To handle an event with multiple consumers, register each consumer with a unique
+name. `EventConsumer` and `EventConsumer1` in this sample both handle login
+events and will be invoked for the same published event.

--- a/src/EventTriggerLibrary/Services/EventConsumer1.cs
+++ b/src/EventTriggerLibrary/Services/EventConsumer1.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Threading.Tasks;
+using EventTriggerLibrary.Events;
+using EventTriggerLibrary.Interfaces;
+
+namespace EventTriggerLibrary.Services
+{
+    public class EventConsumer1 :
+        IConsumer<UserLoginSuccess>,
+        IConsumer<UserLoginFailure>
+    {
+        public Task HandleAsync(UserLoginSuccess @event)
+        {
+            Console.WriteLine($"[Consumer1] Login succeeded for {@event.Username}");
+            return Task.CompletedTask;
+        }
+
+        public Task HandleAsync(UserLoginFailure @event)
+        {
+            Console.WriteLine($"[Consumer1] Login failed for {@event.Username}: {@event.Reason}");
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/LoginConsole/Program.cs
+++ b/src/LoginConsole/Program.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading.Tasks;
 using EventTriggerLibrary.Services;
+using EventTriggerLibrary.Interfaces;
 using Unity;
 
 namespace LoginConsole
@@ -12,8 +13,10 @@ namespace LoginConsole
             var container = new UnityContainer();
             container.RegisterType<IEventPublisher, EventPublisher>(TypeLifetime.Singleton);
             container.RegisterType<IAuthService, AuthService>(TypeLifetime.Singleton);
-            container.RegisterType<IConsumer<EventTriggerLibrary.Events.UserLoginSuccess>, EventConsumer>();
-            container.RegisterType<IConsumer<EventTriggerLibrary.Events.UserLoginFailure>, EventConsumer>();
+            container.RegisterType<IConsumer<EventTriggerLibrary.Events.UserLoginSuccess>, EventConsumer>("consumerA");
+            container.RegisterType<IConsumer<EventTriggerLibrary.Events.UserLoginSuccess>, EventConsumer1>("consumerB");
+            container.RegisterType<IConsumer<EventTriggerLibrary.Events.UserLoginFailure>, EventConsumer>("consumerA");
+            container.RegisterType<IConsumer<EventTriggerLibrary.Events.UserLoginFailure>, EventConsumer1>("consumerB");
 
             var authService = container.Resolve<IAuthService>();
 


### PR DESCRIPTION
## Summary
- add a second event consumer
- register both consumers with Unity using unique names
- document multiple consumer support in README

## Testing
- `dotnet build EventTrigger.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859789993f0832ebdde088e9f426ce5