### PR TITLE
Simplify consumer registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,15 @@ Run the console application and enter credentials. The password `password` is co
 To handle an event with multiple consumers, register each consumer with a unique
 name. `EventConsumer` and `EventConsumer1` in this sample both handle login
 events and will be invoked for the same published event.
+
+### Automatic consumer registration
+
+The library exposes an extension method `RegisterEventConsumers` that scans an
+assembly for all `IConsumer<TEvent>` implementations and registers them using
+their type names. The `LoginConsole` project calls:
+
+```csharp
+container.RegisterEventConsumers(typeof(EventConsumer).Assembly);
+```
+
+This eliminates the need to manually register each event/consumer pair.

--- a/src/EventTriggerLibrary/Extensions/UnityExtensions.cs
+++ b/src/EventTriggerLibrary/Extensions/UnityExtensions.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using Unity;
+using EventTriggerLibrary.Interfaces;
+
+namespace EventTriggerLibrary.Extensions
+{
+    public static class UnityExtensions
+    {
+        /// <summary>
+        /// Registers all implementations of <see cref="IConsumer{T}"/> found in the
+        /// provided assemblies. Each registration uses the consumer type's full
+        /// name as the registration name so multiple consumers for the same
+        /// event can coexist.
+        /// </summary>
+        /// <param name="container">Unity container.</param>
+        /// <param name="assemblies">Assemblies to scan. If empty, the calling
+        /// assembly is scanned.</param>
+        public static void RegisterEventConsumers(this IUnityContainer container,
+            params Assembly[] assemblies)
+        {
+            if (assemblies == null || assemblies.Length == 0)
+            {
+                assemblies = new[] { Assembly.GetCallingAssembly() };
+            }
+
+            foreach (var assembly in assemblies)
+            {
+                var types = assembly.GetTypes()
+                    .Where(t => !t.IsAbstract && !t.IsInterface)
+                    .ToList();
+
+                foreach (var type in types)
+                {
+                    var interfaces = type.GetInterfaces()
+                        .Where(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IConsumer<>));
+
+                    foreach (var iface in interfaces)
+                    {
+                        container.RegisterType(iface, type, type.FullName);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/LoginConsole/Program.cs
+++ b/src/LoginConsole/Program.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading.Tasks;
 using EventTriggerLibrary.Services;
 using EventTriggerLibrary.Interfaces;
+using EventTriggerLibrary.Extensions;
 using Unity;
 
 namespace LoginConsole
@@ -13,10 +14,7 @@ namespace LoginConsole
             var container = new UnityContainer();
             container.RegisterType<IEventPublisher, EventPublisher>(TypeLifetime.Singleton);
             container.RegisterType<IAuthService, AuthService>(TypeLifetime.Singleton);
-            container.RegisterType<IConsumer<EventTriggerLibrary.Events.UserLoginSuccess>, EventConsumer>("consumerA");
-            container.RegisterType<IConsumer<EventTriggerLibrary.Events.UserLoginSuccess>, EventConsumer1>("consumerB");
-            container.RegisterType<IConsumer<EventTriggerLibrary.Events.UserLoginFailure>, EventConsumer>("consumerA");
-            container.RegisterType<IConsumer<EventTriggerLibrary.Events.UserLoginFailure>, EventConsumer1>("consumerB");
+            container.RegisterEventConsumers(typeof(EventConsumer).Assembly);
 
             var authService = container.Resolve<IAuthService>();
 


### PR DESCRIPTION
## Summary
- add `UnityExtensions.RegisterEventConsumers` for automatic consumer registration
- update console app to use the new extension
- document extension usage in README

## Testing
- `dotnet build EventTrigger.sln -v minimal` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68597a2028a0832eb5d60a3d17c79a3e