### PR TITLE
Add user module events and handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,11 @@ All events inherit from `EventBase`, which records the time the event was create
 ### ASP.NET integration
 
 For guidance on configuring Unity and automatic consumer registration in an ASP.NET web application, see [docs/WebApplicationSetup.md](docs/WebApplicationSetup.md).
+
+### User modules
+
+The library now includes sample events for separate user modules:
+`StandardUser`, `GoldUser`, and `DiamondUser`. Each module defines its own
+registration and login events (e.g., `StandardUserRegistered` and
+`GoldUserLoggedIn`). Consumers can implement `IConsumer<TEvent>` for these
+events to run module-specific logic when they are published.

--- a/src/EventTriggerLibrary/Events/DiamondUserLoggedIn.cs
+++ b/src/EventTriggerLibrary/Events/DiamondUserLoggedIn.cs
@@ -1,0 +1,17 @@
+using EventTriggerLibrary.Interfaces;
+
+namespace EventTriggerLibrary.Events
+{
+    /// <summary>
+    /// Event published when a diamond user logs in.
+    /// </summary>
+    public class DiamondUserLoggedIn : EventBase
+    {
+        public string Username { get; }
+
+        public DiamondUserLoggedIn(string username)
+        {
+            Username = username;
+        }
+    }
+}

--- a/src/EventTriggerLibrary/Events/DiamondUserRegistered.cs
+++ b/src/EventTriggerLibrary/Events/DiamondUserRegistered.cs
@@ -1,0 +1,17 @@
+using EventTriggerLibrary.Interfaces;
+
+namespace EventTriggerLibrary.Events
+{
+    /// <summary>
+    /// Event published when a diamond user registers.
+    /// </summary>
+    public class DiamondUserRegistered : EventBase
+    {
+        public string Username { get; }
+
+        public DiamondUserRegistered(string username)
+        {
+            Username = username;
+        }
+    }
+}

--- a/src/EventTriggerLibrary/Events/GoldUserLoggedIn.cs
+++ b/src/EventTriggerLibrary/Events/GoldUserLoggedIn.cs
@@ -1,0 +1,17 @@
+using EventTriggerLibrary.Interfaces;
+
+namespace EventTriggerLibrary.Events
+{
+    /// <summary>
+    /// Event published when a gold user logs in.
+    /// </summary>
+    public class GoldUserLoggedIn : EventBase
+    {
+        public string Username { get; }
+
+        public GoldUserLoggedIn(string username)
+        {
+            Username = username;
+        }
+    }
+}

--- a/src/EventTriggerLibrary/Events/GoldUserRegistered.cs
+++ b/src/EventTriggerLibrary/Events/GoldUserRegistered.cs
@@ -1,0 +1,17 @@
+using EventTriggerLibrary.Interfaces;
+
+namespace EventTriggerLibrary.Events
+{
+    /// <summary>
+    /// Event published when a gold user registers.
+    /// </summary>
+    public class GoldUserRegistered : EventBase
+    {
+        public string Username { get; }
+
+        public GoldUserRegistered(string username)
+        {
+            Username = username;
+        }
+    }
+}

--- a/src/EventTriggerLibrary/Events/StandardUserLoggedIn.cs
+++ b/src/EventTriggerLibrary/Events/StandardUserLoggedIn.cs
@@ -1,0 +1,17 @@
+using EventTriggerLibrary.Interfaces;
+
+namespace EventTriggerLibrary.Events
+{
+    /// <summary>
+    /// Event published when a standard user logs in.
+    /// </summary>
+    public class StandardUserLoggedIn : EventBase
+    {
+        public string Username { get; }
+
+        public StandardUserLoggedIn(string username)
+        {
+            Username = username;
+        }
+    }
+}

--- a/src/EventTriggerLibrary/Events/StandardUserRegistered.cs
+++ b/src/EventTriggerLibrary/Events/StandardUserRegistered.cs
@@ -1,0 +1,17 @@
+using EventTriggerLibrary.Interfaces;
+
+namespace EventTriggerLibrary.Events
+{
+    /// <summary>
+    /// Event published when a standard user registers.
+    /// </summary>
+    public class StandardUserRegistered : EventBase
+    {
+        public string Username { get; }
+
+        public StandardUserRegistered(string username)
+        {
+            Username = username;
+        }
+    }
+}

--- a/src/EventTriggerLibrary/Services/EventConsumer.cs
+++ b/src/EventTriggerLibrary/Services/EventConsumer.cs
@@ -7,7 +7,13 @@ namespace EventTriggerLibrary.Services
 {
     public class EventConsumer :
         IConsumer<UserLoginSuccess>,
-        IConsumer<UserLoginFailure>
+        IConsumer<UserLoginFailure>,
+        IConsumer<StandardUserRegistered>,
+        IConsumer<StandardUserLoggedIn>,
+        IConsumer<GoldUserRegistered>,
+        IConsumer<GoldUserLoggedIn>,
+        IConsumer<DiamondUserRegistered>,
+        IConsumer<DiamondUserLoggedIn>
     {
         public Task HandleAsync(UserLoginSuccess @event)
         {
@@ -18,6 +24,42 @@ namespace EventTriggerLibrary.Services
         public Task HandleAsync(UserLoginFailure @event)
         {
             Console.WriteLine($"Login failed for {@event.Username}: {@event.Reason}");
+            return Task.CompletedTask;
+        }
+
+        public Task HandleAsync(StandardUserRegistered @event)
+        {
+            Console.WriteLine($"Standard user registered: {@event.Username}");
+            return Task.CompletedTask;
+        }
+
+        public Task HandleAsync(StandardUserLoggedIn @event)
+        {
+            Console.WriteLine($"Standard user logged in: {@event.Username}");
+            return Task.CompletedTask;
+        }
+
+        public Task HandleAsync(GoldUserRegistered @event)
+        {
+            Console.WriteLine($"Gold user registered: {@event.Username}");
+            return Task.CompletedTask;
+        }
+
+        public Task HandleAsync(GoldUserLoggedIn @event)
+        {
+            Console.WriteLine($"Gold user logged in: {@event.Username}");
+            return Task.CompletedTask;
+        }
+
+        public Task HandleAsync(DiamondUserRegistered @event)
+        {
+            Console.WriteLine($"Diamond user registered: {@event.Username}");
+            return Task.CompletedTask;
+        }
+
+        public Task HandleAsync(DiamondUserLoggedIn @event)
+        {
+            Console.WriteLine($"Diamond user logged in: {@event.Username}");
             return Task.CompletedTask;
         }
     }


### PR DESCRIPTION
## Summary
- implement events for `StandardUser`, `GoldUser`, and `DiamondUser`
- extend `EventConsumer` to handle new events
- document user module events in the README

## Testing
- `dotnet build EventTrigger.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ae03f4650832ea390ab92cf25b28a