### PR TITLE
Add user type to login events

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ The library now includes sample events for separate user modules:
 registration and login events (e.g., `StandardUserRegistered` and
 `GoldUserLoggedIn`). Consumers can implement `IConsumer<TEvent>` for these
 events to run module-specific logic when they are published.
+`UserLoginSuccess` and `UserLoginFailure` also expose a `UserType` value so
+handlers can react differently based on the user's classification.
 
 ### Grouping user module events
 

--- a/src/EventTriggerLibrary/Events/UserLoginFailure.cs
+++ b/src/EventTriggerLibrary/Events/UserLoginFailure.cs
@@ -9,11 +9,13 @@ namespace EventTriggerLibrary.Events
     {
         public string Username { get; }
         public string Reason { get; }
+        public UserType UserType { get; }
 
-        public UserLoginFailure(string username, string reason)
+        public UserLoginFailure(string username, string reason, UserType userType)
         {
             Username = username;
             Reason = reason;
+            UserType = userType;
         }
     }
 }

--- a/src/EventTriggerLibrary/Events/UserLoginSuccess.cs
+++ b/src/EventTriggerLibrary/Events/UserLoginSuccess.cs
@@ -9,10 +9,12 @@ namespace EventTriggerLibrary.Events
     public class UserLoginSuccess : EventBase
     {
         public string Username { get; }
+        public UserType UserType { get; }
 
-        public UserLoginSuccess(string username)
+        public UserLoginSuccess(string username, UserType userType)
         {
             Username = username;
+            UserType = userType;
         }
     }
 }

--- a/src/EventTriggerLibrary/Interfaces/UserType.cs
+++ b/src/EventTriggerLibrary/Interfaces/UserType.cs
@@ -1,0 +1,12 @@
+namespace EventTriggerLibrary.Interfaces
+{
+    /// <summary>
+    /// Represents user classification for login events.
+    /// </summary>
+    public enum UserType
+    {
+        Standard,
+        Gold,
+        Diamond
+    }
+}

--- a/src/EventTriggerLibrary/Services/AuthService.cs
+++ b/src/EventTriggerLibrary/Services/AuthService.cs
@@ -1,6 +1,7 @@
 using System.Threading.Tasks;
 using EventTriggerLibrary.Events;
 using EventTriggerLibrary.Interfaces;
+using System;
 
 namespace EventTriggerLibrary.Services
 {
@@ -21,13 +22,27 @@ namespace EventTriggerLibrary.Services
         public async Task<bool> LoginAsync(string username, string password)
         {
             // simple demo logic: password must equal "password"
+            var userType = DetermineUserType(username);
             if (password == "password")
             {
-                await _publisher.PublishAsync(new UserLoginSuccess(username));
+                await _publisher.PublishAsync(new UserLoginSuccess(username, userType));
                 return true;
             }
-            await _publisher.PublishAsync(new UserLoginFailure(username, "Invalid password"));
+            await _publisher.PublishAsync(new UserLoginFailure(username, "Invalid password", userType));
             return false;
+        }
+
+        private static UserType DetermineUserType(string username)
+        {
+            if (username?.StartsWith("diamond", StringComparison.OrdinalIgnoreCase) == true)
+            {
+                return UserType.Diamond;
+            }
+            if (username?.StartsWith("gold", StringComparison.OrdinalIgnoreCase) == true)
+            {
+                return UserType.Gold;
+            }
+            return UserType.Standard;
         }
     }
 }

--- a/src/EventTriggerLibrary/Services/EventConsumer.cs
+++ b/src/EventTriggerLibrary/Services/EventConsumer.cs
@@ -13,13 +13,13 @@ namespace EventTriggerLibrary.Services
     {
         public Task HandleAsync(UserLoginSuccess @event)
         {
-            Console.WriteLine($"Login succeeded for {@event.Username}");
+            Console.WriteLine($"Login succeeded for {@event.Username} ({@event.UserType})");
             return Task.CompletedTask;
         }
 
         public Task HandleAsync(UserLoginFailure @event)
         {
-            Console.WriteLine($"Login failed for {@event.Username}: {@event.Reason}");
+            Console.WriteLine($"Login failed for {@event.Username} ({@event.UserType}): {@event.Reason}");
             return Task.CompletedTask;
         }
 

--- a/src/EventTriggerLibrary/Services/EventConsumer1.cs
+++ b/src/EventTriggerLibrary/Services/EventConsumer1.cs
@@ -11,13 +11,13 @@ namespace EventTriggerLibrary.Services
     {
         public Task HandleAsync(UserLoginSuccess @event)
         {
-            Console.WriteLine($"[Consumer1] Login succeeded for {@event.Username}");
+            Console.WriteLine($"[Consumer1] Login succeeded for {@event.Username} ({@event.UserType})");
             return Task.CompletedTask;
         }
 
         public Task HandleAsync(UserLoginFailure @event)
         {
-            Console.WriteLine($"[Consumer1] Login failed for {@event.Username}: {@event.Reason}");
+            Console.WriteLine($"[Consumer1] Login failed for {@event.Username} ({@event.UserType}): {@event.Reason}");
             return Task.CompletedTask;
         }
     }


### PR DESCRIPTION
## Summary
- track user type as part of login events
- derive user type from username in `AuthService`
- log user type when publishing events
- document `UserType` enum usage

## Testing
- `dotnet build EventTrigger.sln` *(fails: dotnet not installed)*
- `msbuild EventTrigger.sln` *(fails: msbuild not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685ae6354bd4832e846b14a60424d44f