### PR TITLE
Add user type interface to login events

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ The library now includes sample events for separate user modules:
 registration and login events (e.g., `StandardUserRegistered` and
 `GoldUserLoggedIn`). Consumers can implement `IConsumer<TEvent>` for these
 events to run module-specific logic when they are published.
+`UserLoginSuccess` and `UserLoginFailure` now expose an `IUserType` instance so
+handlers can react differently based on the user's classification. The library
+provides `StandardUserType`, `GoldUserType`, and `DiamondUserType` classes
+implementing this interface.
 
 ### Grouping user module events
 

--- a/src/EventTriggerLibrary/Events/UserLoginFailure.cs
+++ b/src/EventTriggerLibrary/Events/UserLoginFailure.cs
@@ -5,15 +5,17 @@ namespace EventTriggerLibrary.Events
     /// <summary>
     /// Event published when a user login attempt fails.
     /// </summary>
-    public class UserLoginFailure : EventBase
+    public class UserLoginFailure : EventBase, IHasUserType
     {
         public string Username { get; }
         public string Reason { get; }
+        public IUserType UserType { get; }
 
-        public UserLoginFailure(string username, string reason)
+        public UserLoginFailure(string username, string reason, IUserType userType)
         {
             Username = username;
             Reason = reason;
+            UserType = userType;
         }
     }
 }

--- a/src/EventTriggerLibrary/Events/UserLoginSuccess.cs
+++ b/src/EventTriggerLibrary/Events/UserLoginSuccess.cs
@@ -6,13 +6,15 @@ namespace EventTriggerLibrary.Events
     /// Event published when a user successfully logs in.
     /// Inherits from <see cref="EventBase"/> to provide a timestamp.
     /// </summary>
-    public class UserLoginSuccess : EventBase
+    public class UserLoginSuccess : EventBase, IHasUserType
     {
         public string Username { get; }
+        public IUserType UserType { get; }
 
-        public UserLoginSuccess(string username)
+        public UserLoginSuccess(string username, IUserType userType)
         {
             Username = username;
+            UserType = userType;
         }
     }
 }

--- a/src/EventTriggerLibrary/Interfaces/IHasUserType.cs
+++ b/src/EventTriggerLibrary/Interfaces/IHasUserType.cs
@@ -1,0 +1,10 @@
+namespace EventTriggerLibrary.Interfaces
+{
+    /// <summary>
+    /// Indicates that an event includes user type information.
+    /// </summary>
+    public interface IHasUserType
+    {
+        IUserType UserType { get; }
+    }
+}

--- a/src/EventTriggerLibrary/Interfaces/IUserType.cs
+++ b/src/EventTriggerLibrary/Interfaces/IUserType.cs
@@ -1,0 +1,10 @@
+namespace EventTriggerLibrary.Interfaces
+{
+    /// <summary>
+    /// Provides the classification for a user (Standard, Gold, etc.).
+    /// </summary>
+    public interface IUserType
+    {
+        string Name { get; }
+    }
+}

--- a/src/EventTriggerLibrary/Services/AuthService.cs
+++ b/src/EventTriggerLibrary/Services/AuthService.cs
@@ -1,6 +1,8 @@
 using System.Threading.Tasks;
 using EventTriggerLibrary.Events;
 using EventTriggerLibrary.Interfaces;
+using EventTriggerLibrary.Types;
+using System;
 
 namespace EventTriggerLibrary.Services
 {
@@ -21,13 +23,27 @@ namespace EventTriggerLibrary.Services
         public async Task<bool> LoginAsync(string username, string password)
         {
             // simple demo logic: password must equal "password"
+            var userType = DetermineUserType(username);
             if (password == "password")
             {
-                await _publisher.PublishAsync(new UserLoginSuccess(username));
+                await _publisher.PublishAsync(new UserLoginSuccess(username, userType));
                 return true;
             }
-            await _publisher.PublishAsync(new UserLoginFailure(username, "Invalid password"));
+            await _publisher.PublishAsync(new UserLoginFailure(username, "Invalid password", userType));
             return false;
+        }
+
+        private static IUserType DetermineUserType(string username)
+        {
+            if (username?.StartsWith("diamond", StringComparison.OrdinalIgnoreCase) == true)
+            {
+                return new DiamondUserType();
+            }
+            if (username?.StartsWith("gold", StringComparison.OrdinalIgnoreCase) == true)
+            {
+                return new GoldUserType();
+            }
+            return new StandardUserType();
         }
     }
 }

--- a/src/EventTriggerLibrary/Services/EventConsumer.cs
+++ b/src/EventTriggerLibrary/Services/EventConsumer.cs
@@ -13,13 +13,13 @@ namespace EventTriggerLibrary.Services
     {
         public Task HandleAsync(UserLoginSuccess @event)
         {
-            Console.WriteLine($"Login succeeded for {@event.Username}");
+            Console.WriteLine($"Login succeeded for {@event.Username} ({@event.UserType.Name})");
             return Task.CompletedTask;
         }
 
         public Task HandleAsync(UserLoginFailure @event)
         {
-            Console.WriteLine($"Login failed for {@event.Username}: {@event.Reason}");
+            Console.WriteLine($"Login failed for {@event.Username} ({@event.UserType.Name}): {@event.Reason}");
             return Task.CompletedTask;
         }
 

--- a/src/EventTriggerLibrary/Services/EventConsumer1.cs
+++ b/src/EventTriggerLibrary/Services/EventConsumer1.cs
@@ -11,13 +11,13 @@ namespace EventTriggerLibrary.Services
     {
         public Task HandleAsync(UserLoginSuccess @event)
         {
-            Console.WriteLine($"[Consumer1] Login succeeded for {@event.Username}");
+            Console.WriteLine($"[Consumer1] Login succeeded for {@event.Username} ({@event.UserType.Name})");
             return Task.CompletedTask;
         }
 
         public Task HandleAsync(UserLoginFailure @event)
         {
-            Console.WriteLine($"[Consumer1] Login failed for {@event.Username}: {@event.Reason}");
+            Console.WriteLine($"[Consumer1] Login failed for {@event.Username} ({@event.UserType.Name}): {@event.Reason}");
             return Task.CompletedTask;
         }
     }

--- a/src/EventTriggerLibrary/Services/EventPublisher.cs
+++ b/src/EventTriggerLibrary/Services/EventPublisher.cs
@@ -17,6 +17,12 @@ namespace EventTriggerLibrary.Services
 
         public async Task PublishAsync<TEvent>(TEvent @event) where TEvent : IEvent
         {
+            if (@event is IHasUserType typedEvent)
+            {
+                // Demonstrate that the publisher can access the user type via the interface
+                Console.WriteLine($"Publishing {@event.GetType().Name} for user type {typedEvent.UserType.Name}");
+            }
+
             var handlers = _container.ResolveAll<IConsumer<TEvent>>();
 
             var tasks = new List<Task>();

--- a/src/EventTriggerLibrary/Types/DiamondUserType.cs
+++ b/src/EventTriggerLibrary/Types/DiamondUserType.cs
@@ -1,0 +1,12 @@
+using EventTriggerLibrary.Interfaces;
+
+namespace EventTriggerLibrary.Types
+{
+    /// <summary>
+    /// Highest tier diamond user classification.
+    /// </summary>
+    public class DiamondUserType : IUserType
+    {
+        public string Name => "Diamond";
+    }
+}

--- a/src/EventTriggerLibrary/Types/GoldUserType.cs
+++ b/src/EventTriggerLibrary/Types/GoldUserType.cs
@@ -1,0 +1,12 @@
+using EventTriggerLibrary.Interfaces;
+
+namespace EventTriggerLibrary.Types
+{
+    /// <summary>
+    /// Premium gold user classification.
+    /// </summary>
+    public class GoldUserType : IUserType
+    {
+        public string Name => "Gold";
+    }
+}

--- a/src/EventTriggerLibrary/Types/StandardUserType.cs
+++ b/src/EventTriggerLibrary/Types/StandardUserType.cs
@@ -1,0 +1,12 @@
+using EventTriggerLibrary.Interfaces;
+
+namespace EventTriggerLibrary.Types
+{
+    /// <summary>
+    /// Default user classification.
+    /// </summary>
+    public class StandardUserType : IUserType
+    {
+        public string Name => "Standard";
+    }
+}


### PR DESCRIPTION
## Summary
- replace `UserType` enum with `IUserType` interface and implementations
- update login events to implement `IHasUserType`
- log user type in `EventPublisher`
- update consumers and `AuthService` to use the new classes
- document new user type classes in README

## Testing
- `dotnet build EventTrigger.sln` *(fails: dotnet not installed)*
- `msbuild EventTrigger.sln` *(fails: msbuild not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685ae6354bd4832e846b14a60424d44f